### PR TITLE
Ablestack cerato 컨테이너 이미지 제작 아키텍쳐 변경

### DIFF
--- a/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
+++ b/ceph-releases/ALL/centos/daemon-base/__DOCKERFILE_INSTALL__
@@ -76,7 +76,7 @@ bash -c ' \
     RELEASE_VER=1 ;\
     REPO_URL="http://download.ceph.com/rpm-${CEPH_VERSION}/el__ENV_[DISTRO_VERSION]__/"; \
   fi && \
-  rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[DISTRO_VERSION]__.noarch.rpm" && \
+ # rpm -Uvh "$REPO_URL/noarch/ceph-release-1-${RELEASE_VER}.el__ENV_[DISTRO_VERSION]__.noarch.rpm" && \
   if [[ __ENV_[DISTRO_VERSION]__ -eq 8 ]]; then \
     yum install -y dnf-plugins-core ; \
     yum copr enable -y tchaikov/python-scikit-learn ; \

--- a/src/daemon-base/Dockerfile
+++ b/src/daemon-base/Dockerfile
@@ -20,6 +20,8 @@ __DOCKERFILE_PREINSTALL__
 
 # Escape char after immediately after RUN allows comment in first line
 RUN \
+    echo -e "[glue]\nname=Glue\nbaseurl=http://mirror.ablecloud.io/centos/glue/\ngpgcheck=0\nenabled=1" > /etc/yum.repos.d/glue.repo &&\
+    echo "nameserver 8.8.8.8" > /etc/resolve.conf && \
     # Install all components for the image, whether from packages or web downloads.
     # Typical workflow: add new repos; refresh repos; install packages; package-manager clean;
     #   download and install packages from web, cleaning any files as you go.


### PR DESCRIPTION
ABLESTACK Cerato 컨테이너는 glue rpm을 mirror.ablecloud.io 에 사전 제작된 rpm repo를 yum repo에 등록하고 설치하도록 변경하였습니다.
기존 방식 : ceph 컨테이너를 제작하고 glue rpm을 ceph 컨테이너에 복사하여 rpm 업데이트를 하는 방식
변경된 방식 : 컨테이너 제작 시 glue rpm을 바로 설치할 수 있도록 repo에 등록 (버전 관리 및 ceph-container repo의 의존성을 줄일 수 있음)